### PR TITLE
ci: pin GitHub Actions to commit SHAs + harden Renovate policy (F-09)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,13 +10,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           version: "latest"
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.14"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,9 +16,9 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.14"
 
@@ -29,7 +29,7 @@ jobs:
         run: zip -r blender_mcp_addon.zip blender_addon/
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           files: blender_mcp_addon.zip
           generate_release_notes: true

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,19 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
+    "config:recommended",
+    "helpers:pinGitHubActionDigests"
+  ],
+  "packageRules": [
+    {
+      "description": "Require human review for all GitHub Actions updates (supply-chain)",
+      "matchManagers": ["github-actions"],
+      "automerge": false
+    },
+    {
+      "description": "Do not automerge major updates",
+      "matchUpdateTypes": ["major"],
+      "automerge": false
+    }
   ]
 }


### PR DESCRIPTION
## Summary

- Pins all four GitHub Actions in `ci.yml` and `release.yml` to full 40-character commit SHAs with version comments
- Extends Renovate with `helpers:pinGitHubActionDigests` (auto-pins future updates)
- Adds `packageRules` that disable automerge for all `github-actions` updates and for all major updates
- Fixes the unresolvable `astral-sh/setup-uv@v8` reference that blocks PR #9

Closes #18 (F-09 from the 2026-04-19 security audit).
Supersedes PR #8 and PR #9 — both can be closed after this merges.

## Background

The security audit (`audit/2026-04-19/`) flagged three issues in the CI supply-chain area:

1. Actions reference floating major tags (`@v6`, `@v7`, `@v8`, `@v3`) — vulnerable to the same class of supply-chain attack as [tj-actions](https://unit42.paloaltonetworks.com/github-actions-supply-chain-attack/)
2. The existing Renovate config does not enforce digest pinning on Actions
3. Renovate's PR #9 requests `astral-sh/setup-uv@v8`, but upstream [removed major/minor tags in v8.0.0](https://github.com/astral-sh/setup-uv/releases/tag/v8.0.0) as a supply-chain hardening measure — the tag does not exist, so CI fails with ``Unable to resolve action astral-sh/setup-uv@v8``

Full-SHA pinning with version comments is the upstream-recommended approach (same pattern setup-uv itself recommends in their v8.0.0 release notes).

## Pinned versions

| Action | SHA | Version |
|---|---|---|
| `actions/checkout` | `de0fac2e4500dabe0009e67214ff5f5447ce83dd` | v6.0.2 |
| `astral-sh/setup-uv` | `08807647e7069bb48b6ef5acd8ec9567f424441b` | v8.1.0 |
| `actions/setup-python` | `a309ff8b426b58ec0e2a45f0f869d46889d02405` | v6.2.0 |
| `softprops/action-gh-release` | `b4309332981a82ec1c5618f44dd2e27cc8bfbfda` | v3.0.0 |

## Test plan

- [ ] CI workflow resolves all four pinned SHAs and all jobs pass green
- [ ] Renovate opens a PR on the next run when a newer SHA exists, and the PR is *not* auto-merged
- [ ] Release workflow continues to function on the next tag push (manual verification at next release)
- [ ] Close PR #8 and PR #9 after merge