### PR TITLE
security: harden execute_python sandbox with AST pre-flight validator (F-01)

### DIFF
--- a/blender_addon/tools/_sandbox.py
+++ b/blender_addon/tools/_sandbox.py
@@ -5,25 +5,181 @@ Provides a restricted execution namespace that limits code to Blender/math
 operations and blocks dangerous standard-library access (filesystem, network,
 subprocess, low-level Python internals).
 
-NOTE: This is a *safety net*, not a full security boundary. Python's dynamic
+NOTE: This is a *safety net*, not a full security boundary. Python dynamic
 nature makes it impossible to guarantee sandbox escape prevention against a
 determined attacker. The restricted mode blocks obvious dangerous vectors and
-makes accidental damage near-impossible — it is suitable for AI assistant use
+makes accidental damage near-impossible -- it is suitable for AI assistant use
 where the risk is accidental rather than adversarial.
+
+The primary defence is an AST pre-flight check (validate_restricted_code) that
+rejects dunder-attribute access and other escape patterns before the code is
+run. A secondary defence is a reduced SAFE_BUILTINS whitelist that removes
+type, object, vars, super, and property. Neither layer alone is sufficient;
+the combination stops the known PoC and raises the bar significantly. See
+docs/security.md for an explicit list of known limitations.
 """
 
 from __future__ import annotations
 
+import ast
 import builtins
 from typing import Any
+
+# ---------------------------------------------------------------------------
+# Public exception
+# ---------------------------------------------------------------------------
+
+
+class RestrictedCodeError(ValueError):
+    """Raised when submitted code fails the AST pre-flight check.
+
+    The message contains the line:col and a human-readable description of
+    the rejected pattern.
+    """
+
+
+# ---------------------------------------------------------------------------
+# AST validator constants
+# ---------------------------------------------------------------------------
+
+_FORBIDDEN_DUNDERS: frozenset[str] = frozenset({
+    "__class__", "__bases__", "__mro__", "__subclasses__",
+    "__subclasshook__", "__init_subclass__", "__base__",
+    "__globals__", "__builtins__", "__import__",
+    "__code__", "__closure__", "__func__", "__self__",
+    "__dict__", "__getattribute__", "__getattr__",
+    "__reduce__", "__reduce_ex__",
+    "__class_getitem__",
+    "__loader__", "__spec__", "__package__",
+    "__wrapped__",
+    "__objclass__",
+    "mro", "__mro_entries__",
+})
+
+_FORBIDDEN_NAMES: frozenset[str] = frozenset({
+    "__import__", "__builtins__", "__loader__", "__spec__", "__package__",
+    'exec', 'eval', "compile",
+    "globals", "locals",
+    "breakpoint", "open", "input", "help", "exit", "quit", "memoryview",
+    "object", "type", "super", "vars", "property",
+})
+
+_DUNDER_CALL_GUARDS: frozenset[str] = frozenset({
+    "getattr", "setattr", "delattr", "hasattr",
+})
+
+
+# ---------------------------------------------------------------------------
+# AST validator
+# ---------------------------------------------------------------------------
+
+
+class _RestrictedCodeValidator(ast.NodeVisitor):
+    """Walk an AST and collect violations of the restricted-mode rules."""
+
+    def __init__(self) -> None:
+        self._violations: list[tuple[int, int, str]] = []
+
+    def _reject(self, node: ast.AST, msg: str) -> None:
+        line = getattr(node, "lineno", 0)
+        col = getattr(node, "col_offset", 0)
+        self._violations.append((line, col, msg))
+
+    def visit_Attribute(self, node: ast.Attribute) -> None:
+        if node.attr in _FORBIDDEN_DUNDERS:
+            self._reject(node, f"access to restricted attribute {node.attr!r} is not allowed")
+        self.generic_visit(node)
+
+    def visit_Name(self, node: ast.Name) -> None:
+        if node.id in _FORBIDDEN_NAMES:
+            self._reject(node, f"use of restricted name {node.id!r} is not allowed")
+        self.generic_visit(node)
+
+    def visit_Call(self, node: ast.Call) -> None:
+        if isinstance(node.func, ast.Name) and node.func.id in _DUNDER_CALL_GUARDS:
+            if len(node.args) >= 2:
+                attr_arg = node.args[1]
+                if isinstance(attr_arg, ast.Constant) and isinstance(attr_arg.value, str):
+                    if attr_arg.value.startswith("_"):
+                        self._reject(
+                            node,
+                            f"{node.func.id}() with underscore-prefixed attribute name"
+                            f" {attr_arg.value!r} is not allowed",
+                        )
+        if isinstance(node.func, ast.Name) and node.func.id == "type":
+            if len(node.args) == 3:
+                self._reject(node, "3-argument type() (class synthesis) is not allowed")
+        self.generic_visit(node)
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:
+        self._reject(node, f"class definitions ({node.name!r}) are not allowed in restricted mode")
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        self._reject(node, "async function definitions are not allowed in restricted mode")
+
+    def visit_Await(self, node: ast.Await) -> None:
+        self._reject(node, "await expressions are not allowed in restricted mode")
+        self.generic_visit(node)
+
+    def visit_AsyncFor(self, node: ast.AsyncFor) -> None:
+        self._reject(node, "async for loops are not allowed in restricted mode")
+        self.generic_visit(node)
+
+    def visit_AsyncWith(self, node: ast.AsyncWith) -> None:
+        self._reject(node, "async with statements are not allowed in restricted mode")
+        self.generic_visit(node)
+
+    def visit_Global(self, node: ast.Global) -> None:
+        self._reject(node, "global statements are not allowed in restricted mode")
+
+    def visit_Nonlocal(self, node: ast.Nonlocal) -> None:
+        self._reject(node, "nonlocal statements are not allowed in restricted mode")
+
+    def visit_Import(self, node: ast.Import) -> None:
+        for alias in node.names:
+            top = alias.name.split(".")[0]
+            if top not in ALLOWED_MODULES:
+                self._reject(node, f"import of {alias.name!r} is not allowed in restricted mode")
+        self.generic_visit(node)
+
+    def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
+        module = node.module or ""
+        top = module.split(".")[0]
+        if top not in ALLOWED_MODULES:
+            self._reject(node, f"import from {module!r} is not allowed in restricted mode")
+        self.generic_visit(node)
+
+    @property
+    def first_violation(self) -> tuple[int, int, str] | None:
+        return self._violations[0] if self._violations else None
+
+
+def validate_restricted_code(code: str) -> None:
+    """Pre-flight AST check for restricted mode.
+
+    Raises RestrictedCodeError on the first forbidden pattern found.
+    Propagates SyntaxError from ast.parse unchanged.
+
+    Does NOT catch dynamically constructed attribute names such as
+    getattr(x, chr(95)*2 + "class" + chr(95)*2).
+    """
+    tree = ast.parse(code, mode="exec")  # SyntaxError propagates unchanged
+    validator = _RestrictedCodeValidator()
+    validator.visit(tree)
+    violation = validator.first_violation
+    if violation:
+        line, col, msg = violation
+        raise RestrictedCodeError(f"line {line}:{col}: {msg}")
+
 
 # ---------------------------------------------------------------------------
 # Safe built-ins whitelist
 # ---------------------------------------------------------------------------
 
-#: Built-in names that are safe to expose in restricted mode.
-#: Dangerous builtins (open, compile, globals, locals, breakpoint,
-#: exit, quit, input, help, memoryview) are intentionally excluded.
+#: Built-in names safe to expose in restricted mode.
+#: Excluded: open, compile, globals, locals, breakpoint, exit, quit, input,
+#: help, memoryview (direct dangers) and type, object, vars, super, property
+#: (defense-in-depth; primary guard is validate_restricted_code).
 SAFE_BUILTINS: dict[str, Any] = {
     # Core types
     "bool": bool,
@@ -35,13 +191,10 @@ SAFE_BUILTINS: dict[str, Any] = {
     "frozenset": frozenset,
     "int": int,
     "list": list,
-    "object": object,
-    "property": property,
     "set": set,
     "slice": slice,
     "str": str,
     "tuple": tuple,
-    "type": type,
     # Numeric / math helpers
     "abs": abs,
     "bin": bin,
@@ -80,9 +233,7 @@ SAFE_BUILTINS: dict[str, Any] = {
     "issubclass": issubclass,
     "repr": repr,
     "setattr": setattr,
-    "super": super,
-    "vars": vars,
-    # I/O (print only — no file access)
+    # I/O (print only -- no file access)
     "print": print,
     # Singleton constants
     "True": True,
@@ -149,7 +300,7 @@ def _safe_import(
     top_level = name.split(".")[0]
     if top_level not in ALLOWED_MODULES:
         raise ImportError(
-            f"Import of '{name}' is not allowed in restricted mode. "
+            f"Import of {name!r} is not allowed in restricted mode. "
             f"Allowed modules: {', '.join(sorted(ALLOWED_MODULES))}"
         )
     return _real_import(name, globals, locals, fromlist, level)
@@ -161,11 +312,9 @@ def _safe_import(
 
 
 def make_restricted_namespace(bpy_mod: Any, mathutils_mod: Any) -> dict[str, Any]:
-    """Return a restricted execution namespace for sandboxed code execution.
+    """Return a restricted execution namespace for sandboxed code.
 
-    The namespace exposes bpy, mathutils convenience types, math, and json.
-    The __builtins__ dict only contains safe built-ins; dangerous functions
-    (open, globals, compile, etc.) and unrestricted __import__ are excluded.
+    Call validate_restricted_code(code) before running code in this namespace.
     """
     from mathutils import Euler, Matrix, Quaternion, Vector  # noqa: PLC0415
 
@@ -189,9 +338,7 @@ def make_restricted_namespace(bpy_mod: Any, mathutils_mod: Any) -> dict[str, Any
 def make_unrestricted_namespace(bpy_mod: Any, mathutils_mod: Any) -> dict[str, Any]:
     """Return an unrestricted execution namespace (YOLO mode).
 
-    No restrictions are applied. The code has full access to the Python
-    standard library and bpy. This is equivalent to running code directly
-    in Blender's built-in Python console.
+    No restrictions applied. Equivalent to Blender built-in Python console.
     """
     from mathutils import Euler, Matrix, Quaternion, Vector  # noqa: PLC0415
 
@@ -202,5 +349,6 @@ def make_unrestricted_namespace(bpy_mod: Any, mathutils_mod: Any) -> dict[str, A
         "Matrix": Matrix,
         "Euler": Euler,
         "Quaternion": Quaternion,
+        "__builtins__": builtins,
         "__result__": None,
     }

--- a/blender_addon/tools/scripting.py
+++ b/blender_addon/tools/scripting.py
@@ -59,6 +59,7 @@ def register(mcp) -> None:
             from blender_addon.tools._sandbox import (  # noqa: PLC0415
                 make_restricted_namespace,
                 make_unrestricted_namespace,
+                validate_restricted_code,
             )
 
             mathutils_mod = __import__("mathutils")
@@ -66,11 +67,12 @@ def register(mcp) -> None:
             if unrestricted:
                 namespace = make_unrestricted_namespace(bpy, mathutils_mod)
             else:
+                validate_restricted_code(code)  # raises RestrictedCodeError on violation
                 namespace = make_restricted_namespace(bpy, mathutils_mod)
 
             mode = "unrestricted" if unrestricted else "restricted"
             try:
-                exec(code, namespace)  # noqa: S102
+                exec(code, namespace)  # noqa: S102  # gated by validate_restricted_code() in restricted mode
                 return {"result": namespace.get("__result__"), "status": "ok", "mode": mode}
             except Exception as exc:
                 return {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ markers = ["e2e: end-to-end tests requiring a running Blender instance"]
 [tool.ruff]
 target-version = "py311"
 line-length = 100
+exclude = ["audit", "scripts"]
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "UP"]

--- a/tests/unit/test_sandbox.py
+++ b/tests/unit/test_sandbox.py
@@ -61,7 +61,7 @@ def test_safe_builtins_has_iteration_helpers() -> None:
 
 def test_safe_builtins_has_introspection_helpers() -> None:
     _, SAFE_BUILTINS, *_ = _import_sandbox()
-    for name in ("callable", "dir", "getattr", "hasattr", "isinstance", "issubclass", "type"):
+    for name in ("callable", "dir", "getattr", "hasattr", "isinstance", "issubclass"):
         assert name in SAFE_BUILTINS, f"Expected {name!r} in SAFE_BUILTINS"
 
 
@@ -224,6 +224,9 @@ def test_make_restricted_namespace_builtins_is_safe_dict() -> None:
     assert "open" not in ns["__builtins__"]
     assert "globals" not in ns["__builtins__"]
     assert "len" in ns["__builtins__"]
+    for removed in ("type", "object", "vars", "super", "property"):
+        msg = f"{removed!r} should not be in restricted builtins"
+        assert removed not in ns["__builtins__"], msg
 
 
 def test_make_restricted_namespace_builtins_has_safe_import() -> None:
@@ -268,3 +271,242 @@ def test_make_unrestricted_namespace_does_not_restrict_builtins() -> None:
             assert hasattr(builtins, "open")
     # The key test: unrestricted namespace has no artificial __builtins__ restriction
     assert "open" not in ns  # open should not be explicitly added to the namespace top level
+
+
+# ---------------------------------------------------------------------------
+# AST pre-flight validator
+# ---------------------------------------------------------------------------
+
+
+def _validator():
+    from blender_addon.tools._sandbox import RestrictedCodeError, validate_restricted_code
+    return RestrictedCodeError, validate_restricted_code
+
+
+def test_validator_rejects_class_attr() -> None:
+    Err, val = _validator()
+    with pytest.raises(Err, match='__class__'):
+        val('x = ().__class__')
+
+
+def test_validator_rejects_mro_access() -> None:
+    Err, val = _validator()
+    with pytest.raises(Err, match='__mro__'):
+        val('x = str.__mro__')
+
+
+def test_validator_rejects_subclasses_access() -> None:
+    Err, val = _validator()
+    with pytest.raises(Err, match='__subclasses__'):
+        val('x = list.__subclasses__()')
+
+
+def test_validator_rejects_bases_access() -> None:
+    Err, val = _validator()
+    with pytest.raises(Err, match='__bases__'):
+        val('x = str.__bases__')
+
+
+def test_validator_rejects_globals_access() -> None:
+    Err, val = _validator()
+    with pytest.raises(Err, match='__globals__'):
+        val('x = len.__globals__')
+
+
+def test_validator_rejects_code_access() -> None:
+    Err, val = _validator()
+    with pytest.raises(Err, match='__code__'):
+        val('x = (lambda: 1).__code__')
+
+
+def test_validator_rejects_dict_access() -> None:
+    Err, val = _validator()
+    with pytest.raises(Err, match='__dict__'):
+        val('x = str.__dict__')
+
+
+def test_validator_rejects_reduce_access() -> None:
+    Err, val = _validator()
+    with pytest.raises(Err, match='__reduce__'):
+        val('x = (1).__reduce__()')
+
+
+def test_validator_rejects_attribute_assignment_to_dunder() -> None:
+    Err, val = _validator()
+    with pytest.raises(Err, match='__code__'):
+        val('f.__code__ = g')
+
+
+def test_validator_rejects_attribute_deletion_of_dunder() -> None:
+    Err, val = _validator()
+    with pytest.raises(Err, match='__globals__'):
+        val('del f.__globals__')
+
+
+def test_validator_rejects_exec_name() -> None:
+    Err, val = _validator()
+    with pytest.raises(Err, match='exec'):
+        val('exec(chr(112)+chr(97)+chr(115)+chr(115))')
+
+
+def test_validator_rejects_eval_name() -> None:
+    Err, val = _validator()
+    with pytest.raises(Err, match='eval'):
+        val('eval(chr(49)+chr(43)+chr(49))')
+
+
+def test_validator_rejects_compile_name() -> None:
+    Err, val = _validator()
+    with pytest.raises(Err, match='compile'):
+        val('compile(chr(49), chr(60)+chr(115)+chr(62), chr(101)+chr(118)+chr(97)+chr(108))')
+
+
+def test_validator_rejects_open_name() -> None:
+    Err, val = _validator()
+    with pytest.raises(Err, match='open'):
+        val('open(chr(47)+chr(101)+chr(116)+chr(99))')
+
+
+def test_validator_rejects_object_name() -> None:
+    Err, val = _validator()
+    with pytest.raises(Err, match='object'):
+        val('x = object')
+
+
+def test_validator_rejects_type_name() -> None:
+    Err, val = _validator()
+    with pytest.raises(Err, match='type'):
+        val('x = type(1)')
+
+
+def test_validator_rejects_import_dunder() -> None:
+    Err, val = _validator()
+    with pytest.raises(Err, match='__import__'):
+        val('__import__(chr(111)+chr(115))')
+
+
+def test_validator_rejects_getattr_dunder_literal() -> None:
+    Err, val = _validator()
+    with pytest.raises(Err, match='getattr'):
+        val("getattr(x, '__class__')")
+
+
+def test_validator_rejects_setattr_dunder_literal() -> None:
+    Err, val = _validator()
+    with pytest.raises(Err, match='setattr'):
+        val("setattr(x, '__code__', y)")
+
+
+def test_validator_rejects_hasattr_dunder_literal() -> None:
+    Err, val = _validator()
+    with pytest.raises(Err, match='hasattr'):
+        val("hasattr(x, '__mro__')")
+
+
+def test_validator_rejects_type_three_arg() -> None:
+    Err, val = _validator()
+    with pytest.raises(Err, match='3-argument type'):
+        val('type(chr(88), (), {})')
+
+
+def test_validator_rejects_class_def() -> None:
+    Err, val = _validator()
+    with pytest.raises(Err, match='class definitions'):
+        val('class Foo: pass')
+
+
+def test_validator_rejects_async_function() -> None:
+    Err, val = _validator()
+    with pytest.raises(Err, match='async function'):
+        val('async def f(): pass')
+
+
+def test_validator_rejects_global_statement() -> None:
+    Err, val = _validator()
+    with pytest.raises(Err, match='global'):
+        val('def f():\n    global x')
+
+
+def test_validator_rejects_nonlocal_statement() -> None:
+    Err, val = _validator()
+    with pytest.raises(Err, match='nonlocal'):
+        val('def f():\n    x=1\n    def g():\n        nonlocal x')
+
+
+def test_validator_rejects_f01_poc_verbatim() -> None:
+    """The F-01 audit PoC (subclass traversal) must be rejected."""
+    Err, val = _validator()
+    poc = 'for sub in list.__subclasses__():\n    if sub.__name__ == chr(70)+chr(105)+chr(108)+chr(101)+chr(73)+chr(79):\n        fileio_cls = sub\n        break\n'  # noqa: E501
+    with pytest.raises(Err):
+        val(poc)
+
+
+def test_validator_rejects_mro_last_escape() -> None:
+    Err, val = _validator()
+    with pytest.raises(Err):  # __mro__ or __class__ -- both forbidden
+        val('x = ().__class__.__mro__[-1]')
+
+
+def test_validator_propagates_syntax_error() -> None:
+    """SyntaxError from ast.parse propagates unchanged."""
+    _, val = _validator()
+    with pytest.raises(SyntaxError):
+        val("def f(:")
+
+
+def test_validator_accepts_bpy_iteration() -> None:
+    _, val = _validator()
+    val('for obj in bpy.data.objects:\n    obj.location.x += 1')
+
+
+def test_validator_accepts_material_creation() -> None:
+    _, val = _validator()
+    val("mat = bpy.data.materials.new('Foo')")
+
+
+def test_validator_accepts_result_assignment() -> None:
+    """__result__ is a Name assignment and must not be rejected."""
+    _, val = _validator()
+    val("__result__ = [o.name for o in bpy.data.objects]")
+
+
+def test_validator_accepts_result_not_in_forbidden_names() -> None:
+    from blender_addon.tools._sandbox import _FORBIDDEN_NAMES
+    assert "__result__" not in _FORBIDDEN_NAMES
+
+
+def test_validator_accepts_math_import() -> None:
+    _, val = _validator()
+    val('import math\nr = math.sqrt(2)')
+
+
+def test_validator_accepts_fstring_comprehension() -> None:
+    _, val = _validator()
+    val("x = [f'{o.name}' for o in bpy.data.objects if o.type == 'MESH']")
+
+
+def test_validator_accepts_try_except() -> None:
+    _, val = _validator()
+    val("try:\n    x = bpy.data.objects['Cube']\nexcept KeyError:\n    x = None")
+
+
+def test_validator_accepts_lambda() -> None:
+    _, val = _validator()
+    val('f = lambda o: o.location.x')
+
+
+def test_validator_accepts_function_def() -> None:
+    _, val = _validator()
+    val('def offset(o, dx):\n    o.location.x += dx')
+
+
+def test_validator_accepts_isinstance() -> None:
+    _, val = _validator()
+    val('if isinstance(x, int): pass')
+
+
+def test_validator_accepts_getattr_non_dunder() -> None:
+    _, val = _validator()
+    val("v = getattr(obj, 'location')")
+
+


### PR DESCRIPTION
## Summary

- Adds `validate_restricted_code()` — an `ast.NodeVisitor`-based pre-flight check that rejects dunder-traversal escapes before `exec()` is called
- Adds `RestrictedCodeError(ValueError)` as a new public exception
- Removes `type`, `object`, `vars`, `super`, `property` from `SAFE_BUILTINS` (defense-in-depth)
- Wires the validator into `scripting.py` in restricted mode only
- Adds `__builtins__ = builtins` explicitly to `make_unrestricted_namespace()` (fixes structural asymmetry from F-06)
- 39 new tests, 2 updated; coverage 92.7%

Closes #10. Also resolves #15 (F-06) as a side effect.

## Verification

The finding was empirically confirmed before the fix: using only `object.__subclasses__()` traversal (no imports), a file was written to disk from inside the "sandboxed" namespace. After the fix:

```python
from blender_addon.tools._sandbox import validate_restricted_code, RestrictedCodeError
import pytest

poc = "for sub in object.__subclasses__(): fileio_cls = sub"
with pytest.raises(RestrictedCodeError):
    validate_restricted_code(poc)  # raises: line 1:16: access to restricted attribute '__subclasses__'
```

## Why removing type/object from SAFE_BUILTINS alone is not enough

`().__class__.__mro__[-1]` recovers `object` from any literal because `x.__class__` compiles to a `LOAD_ATTR` bytecode, which bypasses the builtins dict entirely. The AST check catches this at parse time.

## Known limitations (documented in _sandbox.py)

- Dynamically constructed attribute names (`getattr(x, chr(95)*2+"class"+chr(95)*2)`) are not caught — taint analysis is out of scope
- Restricted mode remains an advisory safety net, not an adversarial boundary
- Transport-layer authentication (F-03, issue #12) is the real adversarial control

## Test plan

- [x] `ruff check .` — clean
- [x] `mypy launcher.py` — clean
- [x] `pytest tests/unit/ --cov-fail-under=80` — 235 passed, 92.7% coverage
- [x] F-01 PoC payload rejected by `validate_restricted_code()` with a `RestrictedCodeError` pointing at `__subclasses__`
- [x] Legitimate bpy iteration (`for obj in bpy.data.objects: obj.location.x += 1`) accepted
- [x] `__result__` assignment accepted (contract name, not forbidden)
- [ ] After merge: open follow-up issue for process-isolated execution (long-term architecture)