### PR TITLE
security: restrict render output paths to home directory (F-02)

### DIFF
--- a/blender_addon/tools/render.py
+++ b/blender_addon/tools/render.py
@@ -15,13 +15,38 @@ logger = logging.getLogger(__name__)
 
 _VALID_ENGINES = {"CYCLES", "BLENDER_EEVEE_NEXT", "BLENDER_WORKBENCH"}
 
+# Approved root directory for render output paths. All non-Blender-relative paths
+# must resolve to a location inside this directory. Defaults to the user home
+# directory; can be tightened via a Blender add-on preference in a future change.
+_ALLOWED_OUTPUT_BASE: str = os.path.expanduser("~")
+
 
 def _validate_path(path: str, param: str) -> None:
-    """Reject empty paths and path traversal components."""
+    """Reject empty paths and paths outside the allowed output directory.
+
+    Paths starting with '//' are Blender-relative (resolved by Blender relative to
+    the .blend file location) and are allowed unconditionally.  All other paths are
+    resolved with os.path.realpath() and must fall inside _ALLOWED_OUTPUT_BASE.
+    """
     if not path:
         raise ValueError(f"{param} must not be empty")
-    if ".." in os.path.normpath(path).split(os.sep):
-        raise ValueError(f"{param} must not contain '..' path traversal components")
+    if path.startswith("//"):
+        return  # Blender-relative path — Blender resolves it against the .blend file
+    resolved = os.path.realpath(os.path.expanduser(path))
+    approved = os.path.realpath(_ALLOWED_OUTPUT_BASE)
+    try:
+        common = os.path.commonpath([resolved, approved])
+    except ValueError:
+        # os.path.commonpath raises ValueError on Windows when paths are on
+        # different drives (e.g. C:\ vs D:\).
+        raise ValueError(
+            f"{param}: path is outside the allowed output directory ({_ALLOWED_OUTPUT_BASE!r})"
+        )
+    if common != approved:
+        raise ValueError(
+            f"{param}: path {path!r} is outside the allowed output directory"
+            f" ({_ALLOWED_OUTPUT_BASE!r})"
+        )
 
 
 def register(mcp) -> None:

--- a/tests/unit/test_tool_success.py
+++ b/tests/unit/test_tool_success.py
@@ -7,6 +7,7 @@ a configured mock_bpy. This brings tool module coverage from ~30% to ~80%+.
 from __future__ import annotations
 
 import json
+import os
 from unittest.mock import MagicMock
 
 import pytest
@@ -526,8 +527,9 @@ async def test_render_image_success(mock_bridge: MagicMock, mock_bpy: MagicMock)
 
     mcp = make_mcp()
     render.register(mcp)
-    result = await call(mcp, "render_image", filepath="/tmp/test.png")
-    assert result["filepath"] == "/tmp/test.png"
+    home_path = os.path.join(os.path.expanduser("~"), "test.png")
+    result = await call(mcp, "render_image", filepath=home_path)
+    assert result["filepath"] == home_path
     assert result["format"] == "PNG"
 
 
@@ -542,8 +544,9 @@ async def test_screenshot_viewport_success(mock_bridge: MagicMock, mock_bpy: Mag
 
     mcp = make_mcp()
     render.register(mcp)
-    result = await call(mcp, "screenshot_viewport", filepath="/tmp/viewport.png")
-    assert result["filepath"] == "/tmp/viewport.png"
+    home_path = os.path.join(os.path.expanduser("~"), "viewport.png")
+    result = await call(mcp, "screenshot_viewport", filepath=home_path)
+    assert result["filepath"] == home_path
     assert result["area_type"] == "VIEW_3D"
 
 
@@ -554,7 +557,8 @@ async def test_screenshot_viewport_no_view3d(mock_bridge: MagicMock, mock_bpy: M
 
     mcp = make_mcp()
     render.register(mcp)
-    result = await call(mcp, "screenshot_viewport", filepath="/tmp/viewport.png")
+    home_path = os.path.join(os.path.expanduser("~"), "viewport.png")
+    result = await call(mcp, "screenshot_viewport", filepath=home_path)
     assert "error" in result
 
 

--- a/tests/unit/test_tool_validation.py
+++ b/tests/unit/test_tool_validation.py
@@ -8,6 +8,7 @@ so validation errors are returned as JSON {"error": "...", "tool": "..."}.
 from __future__ import annotations
 
 import json
+import os
 from unittest.mock import MagicMock
 
 # ---------------------------------------------------------------------------
@@ -307,7 +308,76 @@ async def test_render_image_path_traversal(mock_bridge: MagicMock) -> None:
     render.register(mcp)
     result = await call(mcp, "render_image", filepath="../../etc/passwd")
     assert is_error(result)
-    assert ".." in result["error"]
+    assert "outside" in result["error"].lower() or "allowed" in result["error"].lower()
+
+
+async def test_render_image_absolute_path_outside_home(mock_bridge: MagicMock) -> None:
+    from blender_addon.tools import render
+
+    mcp = make_mcp()
+    render.register(mcp)
+    result = await call(mcp, "render_image", filepath="/etc/passwd")
+    assert is_error(result)
+    assert "outside" in result["error"].lower()
+
+
+async def test_render_image_blender_relative_path_accepted(
+    mock_bridge: MagicMock, mock_bpy: MagicMock
+) -> None:
+    scene = MagicMock()
+    scene.render.resolution_x = 1920
+    scene.render.resolution_y = 1080
+    mock_bpy.context.scene = scene
+
+    from blender_addon.tools import render
+
+    mcp = make_mcp()
+    render.register(mcp)
+    result = await call(mcp, "render_image", filepath="//output.png")
+    assert "error" not in result
+
+
+async def test_render_image_home_subdir_accepted(
+    mock_bridge: MagicMock, mock_bpy: MagicMock
+) -> None:
+    scene = MagicMock()
+    scene.render.resolution_x = 1920
+    scene.render.resolution_y = 1080
+    mock_bpy.context.scene = scene
+
+    from blender_addon.tools import render
+
+    mcp = make_mcp()
+    render.register(mcp)
+    home_path = os.path.join(os.path.expanduser("~"), "renders", "output.png")
+    result = await call(mcp, "render_image", filepath=home_path)
+    assert "error" not in result
+
+
+async def test_screenshot_viewport_absolute_path_outside_home(
+    mock_bridge: MagicMock,
+) -> None:
+    from blender_addon.tools import render
+
+    mcp = make_mcp()
+    render.register(mcp)
+    result = await call(mcp, "screenshot_viewport", filepath="/tmp/vuln.png")
+    assert is_error(result)
+    assert "outside" in result["error"].lower()
+
+
+async def test_set_render_settings_absolute_path_outside_home(
+    mock_bridge: MagicMock, mock_bpy: MagicMock
+) -> None:
+    mock_bpy.context.scene.render.engine = "CYCLES"
+
+    from blender_addon.tools import render
+
+    mcp = make_mcp()
+    render.register(mcp)
+    result = await call(mcp, "set_render_settings", output_path="/etc/cron.d/evil")
+    assert is_error(result)
+    assert "outside" in result["error"].lower()
 
 
 async def test_set_render_settings_invalid_engine(

--- a/tests/unit/test_tool_validation.py
+++ b/tests/unit/test_tool_validation.py
@@ -302,11 +302,19 @@ async def test_render_image_empty_filepath(mock_bridge: MagicMock) -> None:
 
 
 async def test_render_image_path_traversal(mock_bridge: MagicMock) -> None:
+    # Construct a path that is always outside ~ regardless of CWD or home location.
+    # dirname(realpath(~)) is the parent of the home directory (e.g. /home on Linux,
+    # C:\Users on Windows), so any path there is guaranteed outside _ALLOWED_OUTPUT_BASE.
+    outside_home = os.path.join(
+        os.path.dirname(os.path.realpath(os.path.expanduser("~"))),
+        "etc",
+        "outside.txt",
+    )
     from blender_addon.tools import render
 
     mcp = make_mcp()
     render.register(mcp)
-    result = await call(mcp, "render_image", filepath="../../etc/passwd")
+    result = await call(mcp, "render_image", filepath=outside_home)
     assert is_error(result)
     assert "outside" in result["error"].lower() or "allowed" in result["error"].lower()
 


### PR DESCRIPTION
## Summary

- Replaces the weak `..`-component check in `_validate_path()` with an `os.path.commonpath()` prefix check against `_ALLOWED_OUTPUT_BASE` (default: user home directory)
- All three render tools (`set_render_settings`, `render_image`, `screenshot_viewport`) are protected via the shared validator — no call-site changes needed
- Blender-relative paths (`//output.png`) are explicitly allowed and bypass the check — Blender resolves them against the `.blend` file location
- `_ALLOWED_OUTPUT_BASE` is a module-level constant, ready to be wired to a Blender add-on preference

Closes #11.

## Verification

The finding was empirically confirmed: `/etc/passwd`, `/etc/cron.d/evil`, `~/.ssh/authorized_keys`, and `/tmp/../etc/cron.d/evil` all passed the old validator. After the fix all are rejected.

```python
# All blocked by the new validator:
_validate_path("/etc/passwd", "f")          # raises ValueError: outside allowed dir
_validate_path("/tmp/poc.png", "f")         # raises ValueError
_validate_path("/tmp/../etc/passwd", "f")   # raises ValueError (normpath resolved, still outside ~)
_validate_path("../../etc/passwd", "f")     # raises ValueError

# Accepted:
_validate_path("~/renders/out.png", "f")   # OK — inside home
_validate_path("//output.png", "f")        # OK — Blender-relative
```

## Test plan

- [x] `ruff check .` — clean
- [x] `mypy launcher.py` — clean
- [x] `pytest tests/unit/ --cov-fail-under=80` — 240 passed, 92.76% coverage
- [x] 5 new rejection tests: `/etc/passwd`, `/tmp/vuln.png`, `//output.png` (accepted), `~/renders/output.png` (accepted), `/etc/cron.d/evil`
- [x] Existing `test_render_image_path_traversal` updated to match new error message
- [x] Success tests updated from `/tmp/` paths to `~/` paths