### PR TITLE
security: add shared-secret Bearer token auth to MCP HTTP endpoint (F-03)

### DIFF
--- a/blender_addon/server.py
+++ b/blender_addon/server.py
@@ -3,13 +3,25 @@ MCP server setup and lifecycle management.
 
 Creates the FastMCP instance, registers all tool modules, and runs the server
 in a background daemon thread using Streamable HTTP transport on localhost:8400.
+
+Authentication
+--------------
+A shared-secret Bearer token is generated on first start and written to
+~/.config/blender-mcp/token (mode 0o600).  The launcher reads the same file
+and injects the Authorization header on every forwarded request.  Any caller
+that cannot present the token receives 401 Unauthorized.
 """
 
 from __future__ import annotations
 
 import logging
+import pathlib
+import secrets
+import stat
 import threading
 
+from mcp.server.auth.middleware.bearer_auth import AccessToken
+from mcp.server.auth.settings import AuthSettings
 from mcp.server.fastmcp import FastMCP
 
 from .tools import register_all
@@ -25,6 +37,39 @@ PORT: int = 8400
 #: Read at tool-call time by scripting.py so mode changes take effect immediately.
 execute_python_unrestricted: bool = False
 
+# Path where the shared-secret token is persisted between add-on restarts.
+TOKEN_PATH: pathlib.Path = pathlib.Path.home() / ".config" / "blender-mcp" / "token"
+
+
+def get_or_create_token() -> str:
+    """Return the shared-secret Bearer token, creating it on first call.
+
+    The token file is created with permissions 0o600 (owner read/write only).
+    Subsequent calls return the existing token unchanged.
+    """
+    TOKEN_PATH.parent.mkdir(parents=True, exist_ok=True)
+    if not TOKEN_PATH.exists():
+        TOKEN_PATH.write_text(secrets.token_hex(32), encoding="ascii")
+        TOKEN_PATH.chmod(stat.S_IRUSR | stat.S_IWUSR)
+    return TOKEN_PATH.read_text(encoding="ascii").strip()
+
+
+class _StaticTokenVerifier:
+    """TokenVerifier that accepts a single pre-shared secret."""
+
+    def __init__(self, token: str) -> None:
+        self._token = token
+
+    async def verify_token(self, token: str) -> AccessToken | None:
+        if token == self._token:
+            return AccessToken(
+                token=token,
+                client_id="blender-mcp-local",
+                scopes=[],
+                expires_at=None,
+            )
+        return None
+
 
 def setup(
     port: int = 8400,
@@ -36,9 +81,21 @@ def setup(
 
     PORT = port
     execute_python_unrestricted = unrestricted
-    mcp = FastMCP("blender-mcp", host="127.0.0.1", port=port)
+
+    token = get_or_create_token()
+    base_url = f"http://127.0.0.1:{port}"
+    mcp = FastMCP(
+        "blender-mcp",
+        host="127.0.0.1",
+        port=port,
+        auth=AuthSettings(
+            issuer_url=base_url,  # type: ignore[arg-type]
+            resource_server_url=f"{base_url}/mcp",  # type: ignore[arg-type]
+        ),
+        token_verifier=_StaticTokenVerifier(token),
+    )
     register_all(mcp, allow_execute_python=allow_execute_python)
-    logger.info("MCP server configured on port %d", port)
+    logger.info("MCP server configured on port %d (token auth enabled)", port)
 
 
 def start() -> None:

--- a/launcher.py
+++ b/launcher.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import pathlib
 import sys
 
 import httpx
@@ -30,14 +31,27 @@ BLENDER_MCP_URL = "http://localhost:8400/mcp"
 RETRY_INTERVAL = 1.0   # seconds between connection attempts
 RETRY_TIMEOUT = 60.0   # total seconds to wait for Blender to become ready
 
+# Must match TOKEN_PATH in blender_addon/server.py
+_TOKEN_PATH = pathlib.Path.home() / ".config" / "blender-mcp" / "token"
 
-async def wait_for_blender() -> None:
+
+def _read_token() -> str | None:
+    """Read the shared-secret token written by the Blender add-on, if it exists."""
+    try:
+        return _TOKEN_PATH.read_text(encoding="ascii").strip()
+    except OSError:
+        return None
+
+
+async def wait_for_blender(auth_headers: dict[str, str]) -> None:
     """Poll the Blender MCP endpoint until it responds or the timeout is exceeded."""
     elapsed = 0.0
     async with httpx.AsyncClient() as client:
         while elapsed < RETRY_TIMEOUT:
             try:
-                response = await client.get(BLENDER_MCP_URL, timeout=5.0)
+                response = await client.get(
+                    BLENDER_MCP_URL, headers=auth_headers, timeout=5.0
+                )
                 if response.status_code < 500:
                     logger.info("Blender MCP server is ready (status %d)", response.status_code)
                     return
@@ -52,13 +66,15 @@ async def wait_for_blender() -> None:
     )
 
 
-async def proxy_request(client: httpx.AsyncClient, line: bytes) -> bytes:
+async def proxy_request(
+    client: httpx.AsyncClient, line: bytes, auth_headers: dict[str, str]
+) -> bytes:
     """POST a raw JSON-RPC line to the Blender MCP server and return the response body."""
     try:
         response = await client.post(
             BLENDER_MCP_URL,
             content=line,
-            headers={"Content-Type": "application/json"},
+            headers={"Content-Type": "application/json", **auth_headers},
             timeout=60.0,
         )
         response.raise_for_status()
@@ -75,7 +91,18 @@ async def proxy_request(client: httpx.AsyncClient, line: bytes) -> bytes:
 
 async def main() -> None:
     """Main event loop: wait for Blender, then proxy stdin → HTTP → stdout."""
-    await wait_for_blender()
+    token = _read_token()
+    auth_headers: dict[str, str] = (
+        {"Authorization": f"Bearer {token}"} if token else {}
+    )
+    if not token:
+        logger.warning(
+            "No token found at %s — requests will be sent without authentication. "
+            "Start Blender with the add-on enabled to generate a token.",
+            _TOKEN_PATH,
+        )
+
+    await wait_for_blender(auth_headers)
 
     loop = asyncio.get_event_loop()
     async with httpx.AsyncClient() as client:
@@ -86,7 +113,7 @@ async def main() -> None:
             line = line.rstrip(b"\n")
             if not line:
                 continue
-            response = await proxy_request(client, line)
+            response = await proxy_request(client, line, auth_headers)
             sys.stdout.buffer.write(response + b"\n")
             sys.stdout.buffer.flush()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -78,7 +78,16 @@ if "mathutils" not in sys.modules:
     sys.modules["mathutils"] = _mathutils_mock  # type: ignore[assignment]
 
 # mcp is a Blender-side dependency; stub it so server.py can be imported.
-for _mod in ("mcp", "mcp.server", "mcp.server.fastmcp"):
+# Include auth submodules needed by blender_addon.server's top-level imports.
+for _mod in (
+    "mcp",
+    "mcp.server",
+    "mcp.server.fastmcp",
+    "mcp.server.auth",
+    "mcp.server.auth.middleware",
+    "mcp.server.auth.middleware.bearer_auth",
+    "mcp.server.auth.settings",
+):
     if _mod not in sys.modules:
         sys.modules[_mod] = MagicMock(name=_mod)  # type: ignore[assignment]
 

--- a/tests/unit/test_launcher.py
+++ b/tests/unit/test_launcher.py
@@ -3,10 +3,13 @@
 from __future__ import annotations
 
 import json
+import pathlib
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
+
+_AUTH = {"Authorization": "Bearer test-token"}
 
 
 async def test_wait_for_blender_succeeds_on_200() -> None:
@@ -23,7 +26,7 @@ async def test_wait_for_blender_succeeds_on_200() -> None:
         mock_client.__aexit__ = AsyncMock(return_value=False)
 
         with patch("httpx.AsyncClient", return_value=mock_client):
-            await launcher.wait_for_blender()  # should not raise
+            await launcher.wait_for_blender(_AUTH)  # should not raise
 
 
 async def test_wait_for_blender_raises_after_timeout() -> None:
@@ -38,7 +41,7 @@ async def test_wait_for_blender_raises_after_timeout() -> None:
 
         with patch("httpx.AsyncClient", return_value=mock_client):
             with pytest.raises(RuntimeError, match="not reachable"):
-                await launcher.wait_for_blender()
+                await launcher.wait_for_blender(_AUTH)
 
 
 async def test_proxy_request_success() -> None:
@@ -52,8 +55,26 @@ async def test_proxy_request_success() -> None:
     mock_client = AsyncMock()
     mock_client.post = AsyncMock(return_value=mock_response)
 
-    result = await launcher.proxy_request(mock_client, b'{"method":"tools/list","id":1}')
+    result = await launcher.proxy_request(
+        mock_client, b'{"method":"tools/list","id":1}', _AUTH
+    )
     assert result == b'{"result": "ok"}'
+
+
+async def test_proxy_request_sends_auth_header() -> None:
+    """proxy_request includes the Authorization header in the POST request."""
+    import launcher
+
+    mock_response = MagicMock()
+    mock_response.content = b'{"result": "ok"}'
+    mock_response.raise_for_status = MagicMock()
+
+    mock_client = AsyncMock()
+    mock_client.post = AsyncMock(return_value=mock_response)
+
+    await launcher.proxy_request(mock_client, b'{"id":1}', _AUTH)
+    call_headers = mock_client.post.call_args.kwargs["headers"]
+    assert call_headers.get("Authorization") == "Bearer test-token"
 
 
 async def test_proxy_request_http_error_returns_error_json() -> None:
@@ -71,7 +92,7 @@ async def test_proxy_request_http_error_returns_error_json() -> None:
         )
     )
 
-    result = await launcher.proxy_request(mock_client, b'{"method":"test","id":1}')
+    result = await launcher.proxy_request(mock_client, b'{"method":"test","id":1}', _AUTH)
     parsed = json.loads(result)
     assert "error" in parsed
     assert parsed["error"]["code"] == 500
@@ -84,7 +105,7 @@ async def test_proxy_request_generic_error_returns_error_json() -> None:
     mock_client = AsyncMock()
     mock_client.post = AsyncMock(side_effect=ConnectionResetError("connection lost"))
 
-    result = await launcher.proxy_request(mock_client, b'{"method":"test","id":1}')
+    result = await launcher.proxy_request(mock_client, b'{"method":"test","id":1}', _AUTH)
     parsed = json.loads(result)
     assert "error" in parsed
     assert parsed["error"]["code"] == -32000
@@ -108,10 +129,30 @@ async def test_main_reads_stdin_and_writes_stdout() -> None:
 
     with patch("launcher.wait_for_blender", new=AsyncMock()):
         with patch("launcher.proxy_request", new=AsyncMock(return_value=response_bytes)):
-            with patch("sys.stdin", MagicMock(buffer=MagicMock(readline=fake_readline))):
-                with patch("sys.stdout", MagicMock(buffer=stdout_buf)):
-                    await launcher.main()
+            with patch("launcher._read_token", return_value="test-token"):
+                with patch("sys.stdin", MagicMock(buffer=MagicMock(readline=fake_readline))):
+                    with patch("sys.stdout", MagicMock(buffer=stdout_buf)):
+                        await launcher.main()
 
     stdout_buf.seek(0)
     written = stdout_buf.read()
     assert response_bytes in written
+
+
+def test_read_token_returns_none_when_file_missing(tmp_path: pathlib.Path) -> None:
+    """_read_token returns None when the token file does not exist."""
+    import launcher
+
+    with patch("launcher._TOKEN_PATH", tmp_path / "nonexistent" / "token"):
+        assert launcher._read_token() is None
+
+
+def test_read_token_returns_content(tmp_path: pathlib.Path) -> None:
+    """_read_token returns the token string when the file exists."""
+    import launcher
+
+    token_file = tmp_path / "token"
+    token_file.write_text("abc123\n", encoding="ascii")
+
+    with patch("launcher._TOKEN_PATH", token_file):
+        assert launcher._read_token() == "abc123"

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import pathlib
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -16,8 +17,14 @@ def test_setup_creates_fastmcp_instance() -> None:
 
     mock_mcp = MagicMock()
     with patch("blender_addon.server.FastMCP", return_value=mock_mcp) as mock_cls:
-        server_mod.setup(port=8400)
-        mock_cls.assert_called_once_with("blender-mcp", host="127.0.0.1", port=8400)
+        with patch("blender_addon.server.get_or_create_token", return_value="tok"):
+            server_mod.setup(port=8400)
+        call_kwargs = mock_cls.call_args
+        assert call_kwargs.args[0] == "blender-mcp"
+        assert call_kwargs.kwargs["host"] == "127.0.0.1"
+        assert call_kwargs.kwargs["port"] == 8400
+        assert call_kwargs.kwargs.get("token_verifier") is not None
+        assert call_kwargs.kwargs.get("auth") is not None
     assert server_mod.mcp is mock_mcp
 
 
@@ -26,9 +33,10 @@ def test_setup_calls_register_all() -> None:
 
     mock_mcp = MagicMock()
     with patch("blender_addon.server.FastMCP", return_value=mock_mcp):
-        with patch("blender_addon.server.register_all") as mock_reg:
-            server_mod.setup(port=9000)
-            mock_reg.assert_called_once_with(mock_mcp, allow_execute_python=False)
+        with patch("blender_addon.server.get_or_create_token", return_value="tok"):
+            with patch("blender_addon.server.register_all") as mock_reg:
+                server_mod.setup(port=9000)
+                mock_reg.assert_called_once_with(mock_mcp, allow_execute_python=False)
 
 
 def test_start_raises_if_setup_not_called() -> None:
@@ -132,3 +140,66 @@ def test_tools_register_all(mock_bpy: MagicMock) -> None:
     mcp = MagicMock()
     # register_all should call each module's register(mcp) without raising
     register_all(mcp)
+
+
+# ---------------------------------------------------------------------------
+# token management
+# ---------------------------------------------------------------------------
+
+
+def test_get_or_create_token_creates_file(tmp_path: pathlib.Path) -> None:
+    import sys
+
+    from blender_addon import server as server_mod
+
+    token_path = tmp_path / "blender-mcp" / "token"
+    with patch.object(server_mod, "TOKEN_PATH", token_path):
+        token = server_mod.get_or_create_token()
+    assert token_path.exists()
+    assert len(token) == 64  # secrets.token_hex(32) produces 64 hex chars
+    if sys.platform != "win32":
+        assert token_path.stat().st_mode & 0o777 == 0o600
+
+
+def test_get_or_create_token_returns_existing(tmp_path: pathlib.Path) -> None:
+    from blender_addon import server as server_mod
+
+    token_path = tmp_path / "blender-mcp" / "token"
+    token_path.parent.mkdir(parents=True)
+    token_path.write_text("existing-token", encoding="ascii")
+
+    with patch.object(server_mod, "TOKEN_PATH", token_path):
+        assert server_mod.get_or_create_token() == "existing-token"
+
+
+async def test_static_token_verifier_accepts_correct_token() -> None:
+    import sys
+
+    from blender_addon import server as server_mod
+
+    # Temporarily swap the conftest MagicMock with the real mcp auth module so
+    # _StaticTokenVerifier uses a concrete AccessToken, not a MagicMock.
+    stub_mods = {
+        k: sys.modules.pop(k)
+        for k in list(sys.modules)
+        if k.startswith("mcp.server.auth") or k in ("mcp.server", "mcp")
+    }
+    try:
+        import importlib
+        real_bearer = importlib.import_module("mcp.server.auth.middleware.bearer_auth")
+        server_mod.AccessToken = real_bearer.AccessToken  # type: ignore[attr-defined]
+        verifier = server_mod._StaticTokenVerifier("secret")
+        result = await verifier.verify_token("secret")
+    finally:
+        sys.modules.update(stub_mods)
+
+    assert result is not None
+    assert result.client_id == "blender-mcp-local"
+
+
+async def test_static_token_verifier_rejects_wrong_token() -> None:
+    from blender_addon.server import _StaticTokenVerifier
+
+    verifier = _StaticTokenVerifier("secret")
+    result = await verifier.verify_token("wrong")
+    assert result is None


### PR DESCRIPTION
## Summary

- Generates a `secrets.token_hex(32)` bearer token at add-on startup, stored at `~/.config/blender-mcp/token` (mode `0o600`)
- Wires FastMCP's built-in `token_verifier` + `AuthSettings` so the streamable-HTTP transport requires `Authorization: Bearer <token>` on every request — unauthenticated callers receive `401 Unauthorized`
- `launcher.py` reads the same token file and injects the header on every forwarded request

Closes #12.

## Why this matters

Without authentication any process on localhost could call any registered MCP tool. When `execute_python` is opt-in-enabled and combined with the F-01 sandbox escape (now fixed in #23), this created a full local code-execution chain. After this PR:

- Clients must possess the token file, which requires local user-level filesystem access
- The attack chain still requires both the token AND the user having enabled `execute_python` — the defence-in-depth posture is now much stronger

## Token lifecycle

| Event | Behaviour |
|---|---|
| First Blender start | Token generated with `secrets.token_hex(32)`, written to `~/.config/blender-mcp/token` with `chmod 0o600` |
| Subsequent Blender starts | Existing token re-used |
| `launcher.py` startup | Reads token file; injects `Authorization: Bearer` header on all requests |
| Launcher starts before Blender | Token file may not exist yet; launcher logs a warning and continues — token is read once at startup, so the add-on must be running first |
| Manual token rotation | Delete `~/.config/blender-mcp/token`; new token generated on next Blender start (launcher must be restarted to pick it up) |

## Test plan

- [x] `ruff check .` — clean
- [x] `mypy launcher.py` — clean
- [x] `pytest tests/unit/ --cov-fail-under=80` — 247 passed, 92.96% coverage
- [x] `get_or_create_token` creates file with correct permissions (skipped on Windows where `chmod` is a no-op)
- [x] `get_or_create_token` returns existing token on second call
- [x] `_StaticTokenVerifier.verify_token("secret")` → `AccessToken(client_id="blender-mcp-local")`
- [x] `_StaticTokenVerifier.verify_token("wrong")` → `None`
- [x] `proxy_request` injects `Authorization` header in POST
- [x] `_read_token` returns `None` when file missing, token string when present