### PR TITLE
ci: enable ruff S ruleset (Bandit-equivalent security rules) (F-10)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,12 @@ line-length = 100
 exclude = ["audit", "scripts"]
 
 [tool.ruff.lint]
-select = ["E", "F", "I", "UP"]
+select = ["E", "F", "I", "UP", "S"]
+
+[tool.ruff.lint.per-file-ignores]
+# S101: assert is idiomatic in pytest
+# S108: /tmp paths in tests are deliberate (mock values or out-of-home rejection tests)
+"tests/**" = ["S101", "S108"]
 
 [tool.mypy]
 python_version = "3.11"


### PR DESCRIPTION
## Summary

- Adds `"S"` to `[tool.ruff.lint] select` in `pyproject.toml`
- Adds `per-file-ignores` for `tests/**` to suppress `S101` (assert — idiomatic in pytest) and `S108` (`/tmp` paths used as deliberate mock values and out-of-home rejection test cases)

Closes #19.

## What the S ruleset covers going forward

From this point, ruff will catch on every commit:
- `S102` — use of `exec()` (existing `# noqa: S102` on `scripting.py:75` is retained — it is accurate documentation)
- `S105/S106/S107` — hardcoded passwords/tokens
- `S108` — insecure temp file usage (in production code)
- `S301/S302/S303` — unsafe deserialization
- `S506` — unsafe YAML load
- `S603/S604/S605/S607` — subprocess security issues

## Why no semgrep CI step

The issue suggests `semgrep/semgrep-action@v1` (floating major tag). This contradicts the supply-chain hardening in PR #20 (F-09) which pins all Actions to full SHA digests. Adding semgrep would require a SHA-pinned action version — tracked separately.

## Test plan

- [x] `ruff check .` — clean
- [x] `mypy launcher.py` — clean
- [x] `pytest tests/unit/ --cov-fail-under=80` — 247 passed