### PR TITLE
security: validate data_path against allowlist in keyframe tools (F-05)

### DIFF
--- a/blender_addon/tools/animation.py
+++ b/blender_addon/tools/animation.py
@@ -12,6 +12,38 @@ from ._helpers import run_tool
 
 logger = logging.getLogger(__name__)
 
+#: Data paths that callers may keyframe. Restricts the RNA path surface to
+#: standard object transform and visibility properties, preventing accidental
+#: or malicious animation of modifier internals or other arbitrary attributes.
+ALLOWED_DATA_PATHS: frozenset[str] = frozenset({
+    "color",
+    "delta_location",
+    "delta_rotation_euler",
+    "delta_rotation_quaternion",
+    "delta_scale",
+    "hide_render",
+    "hide_viewport",
+    "location",
+    "rotation_axis_angle",
+    "rotation_euler",
+    "rotation_quaternion",
+    "scale",
+})
+
+
+def _validate_data_path(data_path: str) -> None:
+    """Raise ValueError if data_path is not in ALLOWED_DATA_PATHS.
+
+    Indexed access such as ``location[0]`` is accepted by stripping the
+    ``[...]`` suffix before checking the base property name.
+    """
+    base = data_path.split("[")[0].strip()
+    if base not in ALLOWED_DATA_PATHS:
+        raise ValueError(
+            f"data_path {data_path!r} is not allowed. "
+            f"Allowed paths: {', '.join(sorted(ALLOWED_DATA_PATHS))}"
+        )
+
 
 def register(mcp) -> None:
     """Register all animation tools onto the FastMCP instance."""
@@ -65,7 +97,11 @@ def register(mcp) -> None:
     ) -> str:
         """Insert a keyframe on an object's data path at the given frame.
 
-        data_path examples: 'location', 'rotation_euler', 'scale'.
+        data_path must be one of the allowed transform/visibility properties:
+        location, rotation_euler, rotation_quaternion, rotation_axis_angle,
+        scale, hide_render, hide_viewport, color, delta_location, delta_scale,
+        delta_rotation_euler, delta_rotation_quaternion.
+        Indexed access like 'location[0]' is also accepted.
         index=-1 inserts keyframes on all channels of the property.
         """
 
@@ -74,6 +110,7 @@ def register(mcp) -> None:
                 raise ValueError("object_name must not be empty")
             if not data_path:
                 raise ValueError("data_path must not be empty")
+            _validate_data_path(data_path)
             if frame < 0:
                 raise ValueError("frame must be >= 0")
             obj = bpy.data.objects.get(object_name)
@@ -94,7 +131,9 @@ def register(mcp) -> None:
     ) -> str:
         """Delete a keyframe from an object's data path at the given frame.
 
-        Returns success=true if a keyframe was found and removed, false otherwise.
+        data_path must be one of the allowed transform/visibility properties
+        (same set as insert_keyframe). Returns success=true if a keyframe was
+        found and removed, false otherwise.
         """
 
         def _do():
@@ -102,6 +141,7 @@ def register(mcp) -> None:
                 raise ValueError("object_name must not be empty")
             if not data_path:
                 raise ValueError("data_path must not be empty")
+            _validate_data_path(data_path)
             if frame < 0:
                 raise ValueError("frame must be >= 0")
             obj = bpy.data.objects.get(object_name)

--- a/tests/unit/test_tool_validation.py
+++ b/tests/unit/test_tool_validation.py
@@ -1306,3 +1306,65 @@ async def test_add_modifier_extreme_levels_clamped(
                         object_name='Cube', modifier_type='SUBSURF',
                         settings={'levels': 2_000_000_000})
     assert 'error' not in result
+
+
+# ---------------------------------------------------------------------------
+# keyframe data_path allowlist
+# ---------------------------------------------------------------------------
+
+
+async def test_insert_keyframe_disallowed_data_path(mock_bridge: MagicMock) -> None:
+    from blender_addon.tools import animation
+
+    mcp = make_mcp()
+    animation.register(mcp)
+    result = await call(mcp, 'insert_keyframe',
+                        object_name='Cube',
+                        data_path='modifiers["Subdivision"].levels',
+                        frame=1)
+    assert is_error(result)
+    assert 'not allowed' in result['error'].lower()
+
+
+async def test_insert_keyframe_indexed_path_accepted(
+    mock_bridge: MagicMock, mock_bpy: MagicMock
+) -> None:
+    obj = MagicMock()
+    mock_bpy.data.objects.get.return_value = obj
+
+    from blender_addon.tools import animation
+
+    mcp = make_mcp()
+    animation.register(mcp)
+    result = await call(mcp, 'insert_keyframe',
+                        object_name='Cube', data_path='location[0]', frame=1)
+    assert 'error' not in result
+
+
+async def test_insert_keyframe_allowed_paths_accepted(
+    mock_bridge: MagicMock, mock_bpy: MagicMock
+) -> None:
+    obj = MagicMock()
+    mock_bpy.data.objects.get.return_value = obj
+
+    from blender_addon.tools import animation
+
+    for path in ('location', 'rotation_euler', 'scale', 'hide_render', 'hide_viewport'):
+        mcp = make_mcp()
+        animation.register(mcp)
+        result = await call(mcp, 'insert_keyframe',
+                            object_name='Cube', data_path=path, frame=1)
+        assert 'error' not in result, f'Allowed path {path!r} was rejected: {result}'
+
+
+async def test_delete_keyframe_disallowed_data_path(mock_bridge: MagicMock) -> None:
+    from blender_addon.tools import animation
+
+    mcp = make_mcp()
+    animation.register(mcp)
+    result = await call(mcp, 'delete_keyframe',
+                        object_name='Cube',
+                        data_path='modifiers["X"].levels',
+                        frame=1)
+    assert is_error(result)
+    assert 'not allowed' in result['error'].lower()


### PR DESCRIPTION
## Summary

- Adds `ALLOWED_DATA_PATHS` frozenset (12 standard transform/visibility properties) to `animation.py`
- Adds `_validate_data_path()` that strips `[index]` suffix and checks the base name against the allowlist
- Calls the validator in both `insert_keyframe` and `delete_keyframe` before the RNA call
- Updates docstrings of both tools to list the allowed paths

Closes #14.

## What is allowed / blocked

```python
# Allowed
_validate_data_path("location")         # ✓
_validate_data_path("location[0]")      # ✓ indexed access
_validate_data_path("rotation_euler")   # ✓
_validate_data_path("hide_render")      # ✓

# Blocked
_validate_data_path('modifiers["X"].levels')  # ✗ — not in allowlist
_validate_data_path("__class__")              # ✗
_validate_data_path('data["CustomProp"]')     # ✗
```

## Allowed paths

`color`, `delta_location`, `delta_rotation_euler`, `delta_rotation_quaternion`, `delta_scale`, `hide_render`, `hide_viewport`, `location`, `rotation_axis_angle`, `rotation_euler`, `rotation_quaternion`, `scale`

## Test plan

- [x] `ruff check .` — clean
- [x] `mypy launcher.py` — clean
- [x] `pytest tests/unit/ --cov-fail-under=80` — 251 passed, 93.01% coverage
- [x] Disallowed path `modifiers["X"].levels` → error "not allowed"
- [x] Indexed path `location[0]` → accepted
- [x] All 5 spot-checked allowed paths (`location`, `rotation_euler`, `scale`, `hide_render`, `hide_viewport`) → accepted
- [x] `delete_keyframe` with disallowed path → error