### PR TITLE
security: validate node_type against allowlist in add_shader_node (F-07)

### DIFF
--- a/blender_addon/tools/nodes.py
+++ b/blender_addon/tools/nodes.py
@@ -12,6 +12,122 @@ from ._helpers import run_tool
 
 logger = logging.getLogger(__name__)
 
+#: Allowed shader node type strings for add_shader_node.
+#: Covers the full documented ShaderNode* set available in Blender's
+#: material node editor. Internal, compositor, and geometry-node types
+#: are intentionally excluded.
+ALLOWED_SHADER_NODE_TYPES: frozenset[str] = frozenset({
+    # Input
+    "ShaderNodeAmbientOcclusion",
+    "ShaderNodeAttribute",
+    "ShaderNodeBevel",
+    "ShaderNodeCameraData",
+    "ShaderNodeFresnel",
+    "ShaderNodeHairInfo",
+    "ShaderNodeLayerWeight",
+    "ShaderNodeLightPath",
+    "ShaderNodeObjectInfo",
+    "ShaderNodeParticleInfo",
+    "ShaderNodePointInfo",
+    "ShaderNodeRGB",
+    "ShaderNodeTangent",
+    "ShaderNodeTexCoord",
+    "ShaderNodeUVAlongStroke",
+    "ShaderNodeUVMap",
+    "ShaderNodeValue",
+    "ShaderNodeVertexColor",
+    "ShaderNodeVolumeInfo",
+    "ShaderNodeWireframe",
+    # Output
+    "ShaderNodeOutputAOV",
+    "ShaderNodeOutputLight",
+    "ShaderNodeOutputLineStyle",
+    "ShaderNodeOutputMaterial",
+    "ShaderNodeOutputWorld",
+    # Shader
+    "ShaderNodeAddShader",
+    "ShaderNodeBackground",
+    "ShaderNodeBsdfAnisotropic",
+    "ShaderNodeBsdfDiffuse",
+    "ShaderNodeBsdfGlass",
+    "ShaderNodeBsdfGlossy",
+    "ShaderNodeBsdfHair",
+    "ShaderNodeBsdfHairPrincipled",
+    "ShaderNodeBsdfPrincipled",
+    "ShaderNodeBsdfRefraction",
+    "ShaderNodeBsdfSheen",
+    "ShaderNodeBsdfToon",
+    "ShaderNodeBsdfTranslucent",
+    "ShaderNodeBsdfTransparent",
+    "ShaderNodeBsdfVelvet",
+    "ShaderNodeEmission",
+    "ShaderNodeHoldout",
+    "ShaderNodeMixShader",
+    "ShaderNodeSubsurfaceScattering",
+    "ShaderNodeVolumePrincipled",
+    "ShaderNodeVolumeScatter",
+    "ShaderNodeVolumeAbsorption",
+    # Texture
+    "ShaderNodeTexBrick",
+    "ShaderNodeTexChecker",
+    "ShaderNodeTexEnvironment",
+    "ShaderNodeTexGradient",
+    "ShaderNodeTexIES",
+    "ShaderNodeTexImage",
+    "ShaderNodeTexMagic",
+    "ShaderNodeTexMusgrave",
+    "ShaderNodeTexNoise",
+    "ShaderNodeTexPointDensity",
+    "ShaderNodeTexSky",
+    "ShaderNodeTexVoronoi",
+    "ShaderNodeTexWave",
+    "ShaderNodeTexWhiteNoise",
+    # Color
+    "ShaderNodeBrightContrast",
+    "ShaderNodeGamma",
+    "ShaderNodeHueSaturation",
+    "ShaderNodeInvert",
+    "ShaderNodeLightFalloff",
+    "ShaderNodeMix",
+    "ShaderNodeMixRGB",
+    "ShaderNodeRGBCurve",
+    # Vector
+    "ShaderNodeBump",
+    "ShaderNodeDisplacement",
+    "ShaderNodeMapping",
+    "ShaderNodeNormal",
+    "ShaderNodeNormalMap",
+    "ShaderNodeVectorCurve",
+    "ShaderNodeVectorDisplacement",
+    "ShaderNodeVectorMath",
+    "ShaderNodeVectorRotate",
+    "ShaderNodeVectorTransform",
+    # Converter
+    "ShaderNodeBlackbody",
+    "ShaderNodeClamp",
+    "ShaderNodeCombineColor",
+    "ShaderNodeCombineHSV",
+    "ShaderNodeCombineRGB",
+    "ShaderNodeCombineXYZ",
+    "ShaderNodeFloatCurve",
+    "ShaderNodeMapRange",
+    "ShaderNodeMath",
+    "ShaderNodeRGBToBW",
+    "ShaderNodeSeparateColor",
+    "ShaderNodeSeparateHSV",
+    "ShaderNodeSeparateRGB",
+    "ShaderNodeSeparateXYZ",
+    "ShaderNodeShaderToRGB",
+    "ShaderNodeValToRGB",
+    "ShaderNodeWavelength",
+    # Layout / utility
+    "ShaderNodeFrame",
+    "NodeReroute",
+    "ShaderNodeGroup",
+    "NodeGroupInput",
+    "NodeGroupOutput",
+})
+
 
 def register(mcp) -> None:
     """Register all shader node tools onto the FastMCP instance."""
@@ -58,6 +174,11 @@ def register(mcp) -> None:
                 raise ValueError("material_name must not be empty")
             if not node_type:
                 raise ValueError("node_type must not be empty")
+            if node_type not in ALLOWED_SHADER_NODE_TYPES:
+                raise ValueError(
+                    f"node_type {node_type!r} is not allowed. "
+                    f"Allowed types: {', '.join(sorted(ALLOWED_SHADER_NODE_TYPES))}"
+                )
             if len(location) != 2:
                 raise ValueError("location must have 2 components [x, y]")
             mat = bpy.data.materials.get(material_name)

--- a/tests/unit/test_tool_validation.py
+++ b/tests/unit/test_tool_validation.py
@@ -1368,3 +1368,30 @@ async def test_delete_keyframe_disallowed_data_path(mock_bridge: MagicMock) -> N
                         frame=1)
     assert is_error(result)
     assert 'not allowed' in result['error'].lower()
+
+
+# ---------------------------------------------------------------------------
+# shader node type allowlist
+# ---------------------------------------------------------------------------
+
+
+async def test_add_shader_node_disallowed_type(mock_bridge: MagicMock) -> None:
+    from blender_addon.tools import nodes
+
+    mcp = make_mcp()
+    nodes.register(mcp)
+    result = await call(mcp, 'add_shader_node',
+                        material_name='Mat', node_type='InternalNodeType')
+    assert is_error(result)
+    assert 'not allowed' in result['error'].lower()
+
+
+async def test_add_shader_node_compositor_type_disallowed(mock_bridge: MagicMock) -> None:
+    from blender_addon.tools import nodes
+
+    mcp = make_mcp()
+    nodes.register(mcp)
+    result = await call(mcp, 'add_shader_node',
+                        material_name='Mat', node_type='CompositorNodeBlur')
+    assert is_error(result)
+    assert 'not allowed' in result['error'].lower()


### PR DESCRIPTION
## Summary

- Adds `ALLOWED_SHADER_NODE_TYPES` frozenset covering the full documented `ShaderNode*` set (~100 types across input, output, shader, texture, color, vector, converter, and layout categories)
- Validates `node_type` before calling `nodes.new()` and raises `ValueError` with a descriptive message
- Compositor, geometry-node, and internal Blender node types are explicitly excluded

Closes #16.

## What is allowed / blocked

```python
# Allowed — documented shader node types
add_shader_node(material_name="Mat", node_type="ShaderNodeBsdfPrincipled")  # ✓
add_shader_node(material_name="Mat", node_type="ShaderNodeTexImage")        # ✓
add_shader_node(material_name="Mat", node_type="NodeReroute")               # ✓

# Blocked — internal / compositor / undocumented types
add_shader_node(material_name="Mat", node_type="CompositorNodeBlur")     # ✗
add_shader_node(material_name="Mat", node_type="InternalNodeType")        # ✗
add_shader_node(material_name="Mat", node_type="GeometryNodeMeshBoolean") # ✗
```

## Test plan

- [x] `ruff check .` — clean
- [x] `mypy launcher.py` — clean
- [x] `pytest tests/unit/ --cov-fail-under=80` — 261 passed, 93.30% coverage
- [x] Existing `test_add_shader_node_success` with `ShaderNodeTexChecker` still passes (in allowlist)
- [x] `InternalNodeType` → rejected, "not allowed"
- [x] `CompositorNodeBlur` → rejected, "not allowed"